### PR TITLE
use asynchronous sending + immediate waiting.

### DIFF
--- a/src/gniazdo/core.clj
+++ b/src/gniazdo/core.clj
@@ -19,16 +19,16 @@
 (extend-protocol Sendable
   java.lang.String
   (send-to-endpoint [msg ^RemoteEndpoint e]
-    (.sendString e msg))
+    @(.sendStringByFuture e msg))
 
   java.nio.ByteBuffer
   (send-to-endpoint [buf ^RemoteEndpoint e]
-    (.sendBytes e buf)))
+    @(.sendBytesByFuture e buf)))
 
 (extend-type (class (byte-array 0))
   Sendable
   (send-to-endpoint [data ^RemoteEndpoint e]
-    (.sendBytes e (ByteBuffer/wrap data))))
+    @(.sendBytesByFuture e (ByteBuffer/wrap data))))
 
 ;; ## Client
 


### PR DESCRIPTION
The synchronous send methods (`sendString`, `sendBytes`) only allow for
one pending message at any time - meaning that sending of a message
before the previous one is processed will fail with an exception ([see here](http://git.io/Ja3iFg)).

This effectively makes the websocket only usable by one thread as
concurrent operations have a certain likelyhood to fail (depending on
send frequency).
