### PR TITLE
Upgrade 'websocket-client' and 'http-kit' Dependencies.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject stylefruits/gniazdo "0.2.3-SNAPSHOT"
   :description "A WebSocket client for Clojure"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.eclipse.jetty.websocket/websocket-client "9.2.1.v20140609"]]
+                 [org.eclipse.jetty.websocket/websocket-client "9.3.0.M0"]]
   :repl-options {:init-ns gniazdo.core}
   :jvm-opts ["-Dorg.eclipse.jetty.websocket.client.LEVEL=WARN"]
   :profiles {:dev
-             {:dependencies [[http-kit "2.1.13"]]}})
+             {:dependencies [[http-kit "2.1.19"]]}})


### PR DESCRIPTION
`[org.eclipse.jetty.websocket/websocket-client "9.3.0.M0"]` contains a fix for [this bug](https://bugs.eclipse.org/bugs/show_bug.cgi?id=444748) and `WebSocketClient` objects now get garbage collected. See the behaviour when opening/closing a few thousand sockets in quick succession:

![image](https://cloud.githubusercontent.com/assets/198072/4466956/5e1a9c18-48ea-11e4-86e0-d3c8df57de59.png)

Previously:

![image](https://cloud.githubusercontent.com/assets/198072/4466999/fed39718-48ea-11e4-8f6f-29c5bebf7057.png)
