### PR TITLE
Add an arity to close which includes a status code and reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ See also [WebSocketListener][listener].
 with `gniazdo.core/connect`. The message should be a `String`, `byte[]` or
 `java.nio.ByteBuffer`.
 
-### `(gniazdo.core/close [conn])`
+### `(gniazdo.core/close [conn] [conn status-code reason])`
 
 `gniazdo.core/close` closes a connection established with
-`gniazdo.core/connect`.
+`gniazdo.core/connect`. Optionally includes a status int and reason.
 
 ### `(gniazdo.core/client [] [uri])`
 

--- a/src/gniazdo/core.clj
+++ b/src/gniazdo/core.clj
@@ -141,9 +141,9 @@
              (cleanup))
            (.close session))
          (close [_ status-code reason]
+           (.close session status-code reason)
            (when cleanup
-             (cleanup))
-           (.close session status-code reason))))))
+             (cleanup)))))))
 
 (defn- connect-helper
   [^URI uri opts]

--- a/src/gniazdo/core.clj
+++ b/src/gniazdo/core.clj
@@ -37,7 +37,7 @@
 (defprotocol ^:private Client
   (send-msg [this msg]
     "Sends a message (implementing `gniazdo.core/Sendable`) to the given WebSocket.")
-  (close [this]
+  (close [this] [this status-code reason]
     "Closes the WebSocket."))
 
 ;; ## WebSocket Helpers
@@ -139,7 +139,11 @@
          (close [_]
            (when cleanup
              (cleanup))
-           (.close session))))))
+           (.close session))
+         (close [_ status-code reason]
+           (when cleanup
+             (cleanup))
+           (.close session status-code reason))))))
 
 (defn- connect-helper
   [^URI uri opts]


### PR DESCRIPTION
For one of my applications using gniazdo I need to be able to send a close code other than 1000 to the other side of the websocket connection. This PR adds that ability as an additional arity of the close function.