### PR TITLE
fix tautological assertion

### DIFF
--- a/test/gniazdo/core_test.clj
+++ b/test/gniazdo/core_test.clj
@@ -148,7 +148,6 @@
                              (reset! result (.. session getUpgradeRequest getExtensions))
                              (.release sem)))]
     (with-timeout (.acquire sem))
-    (is (-> @result
-          (.get 0)
-          (.getName)) "permessage-deflate")
+    (is (= (-> @result (.get 0) (.getName))
+           "permessage-deflate"))
     (close conn)))


### PR DESCRIPTION
without the predicate fn `(is ...)` can't fail.