### PR TITLE
clean up after closing session.

### DIFF
--- a/src/gniazdo/core.clj
+++ b/src/gniazdo/core.clj
@@ -137,9 +137,9 @@
          (send-msg [_ msg]
            (send-to-endpoint msg (.getRemote session)))
          (close [_]
+           (.close session)
            (when cleanup
-             (cleanup))
-           (.close session))
+             (cleanup)))
          (close [_ status-code reason]
            (.close session status-code reason)
            (when cleanup


### PR DESCRIPTION
default cleanup involves stopping the client, wich makes closing the
session redundant. (see #36)